### PR TITLE
Corrected path to MacOS Freeplane directory

### DIFF
--- a/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
+++ b/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
@@ -53,7 +53,7 @@ class FreeplaneAddonPlugin implements Plugin<Project> {
 
             afterEvaluate {
                 assert configuration.freeplaneDirectory != null : "freeplane directory should be set"
-                String osSpecificPath = Os.isFamily(Os.FAMILY_MAC) ? 'Contents/Java/' : ''
+                String osSpecificPath = Os.isFamily(Os.FAMILY_MAC) ? 'Contents/app/' : ''
                 dependencies {
                     compileOnly fileTree("$configuration.freeplaneDirectory/$osSpecificPath"){
                         include '*.jar'


### PR DESCRIPTION
The Freeplane Add-on plugin was not working on MacOS because the plugin
was adding 'Contents/Java' to the path. 'Contents/app' is the correct
addition. Maybe it is better to leave this addition away and put the
full Freeplane directory path for MacOS  in the README.

If you agree I will remove `osSpecificPath` from FreeplaneAddonPlugin.groovy and add a second commit to this pull request

In addition './gradlew packageAddon' works under JVM 11 and 17 as well.

In the second commit I can also update the README.md with this information