### PR TITLE
fix userDirectory for Linux

### DIFF
--- a/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
+++ b/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
@@ -14,7 +14,7 @@ class FreeplaneAddonPluginExtension {
     def includes = ['**/*']
     def excludes = ['**/*.bak', '**/~*', '**/$~*.mm~', '**/*.gdsl', '**/*.dsld']
     String maxHeapSize = '1024m'
-    String userDirectory = Os.isFamily(Os.FAMILY_WINDOWS) ? "${System.env.APPDATA}/Freeplane" : null
+    String userDirectory = Os.isFamily(Os.FAMILY_WINDOWS) ? "${System.env.APPDATA}/Freeplane" : Os.isFamily(Os.FAMILY_UNIX) ? (System.env.XDG_CONFIG_HOME ?: "${System.env.HOME}/.config" + '/freeplane') : null
     def jvmArgs = null
 }
 


### PR DESCRIPTION
i.e. use the same logic as in freeplane.sh, so that `packageAddon` no longer fails to execute addons.devtools.releaseAddOn_on_single_node