### PR TITLE
Scripts configuration separate from test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.freeplane:gradle-freeplane-plugin:0.6'
+        classpath 'org.freeplane:gradle-freeplane-plugin:0.8'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility='1.8'
 sourceCompatibility='1.8'
 
 group 'org.freeplane'
-version='0.7'
+version='0.8'
 
 
 dependencies {

--- a/examples/greetings/build.gradle
+++ b/examples/greetings/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.freeplane:gradle-freeplane-plugin:0.7'
+        classpath 'org.freeplane:gradle-freeplane-plugin:0.8'
     }
 }
 

--- a/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
+++ b/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
@@ -29,9 +29,11 @@ class FreeplaneAddonPlugin implements Plugin<Project> {
                 ivy
                 addon
                 compileOnly.extendsFrom(addon)
+                scriptsImplementation.extendsFrom(implementation)
             }
             dependencies {
                 ivy "org.apache.ivy:ivy:2.4.0"
+                scriptsImplementation sourceSets.main.output
             }
             tasks.withType(GroovyCompile) {
                 groovyClasspath += configurations.ivy
@@ -46,7 +48,12 @@ class FreeplaneAddonPlugin implements Plugin<Project> {
 
                 test {
                     groovy {
-                        srcDirs = ['src/test/groovy', 'src/scripts/groovy']
+                        srcDirs = ['src/test/groovy']
+                    }
+                }
+                scripts {
+                    groovy {
+                        srcDirs = ['src/scripts/groovy']
                     }
                 }
             }
@@ -68,8 +75,8 @@ class FreeplaneAddonPlugin implements Plugin<Project> {
                 }
 
                 sourceSets {
-                    test.compileClasspath += configurations.compileClasspath
-                    test.runtimeClasspath += configurations.compileClasspath
+                    scripts.compileClasspath += configurations.compileClasspath
+                    scripts.runtimeClasspath += configurations.compileClasspath
                 }
 
                 task ('prepareAddonSource', type: Sync) {

--- a/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
+++ b/src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
@@ -77,6 +77,8 @@ class FreeplaneAddonPlugin implements Plugin<Project> {
                 sourceSets {
                     scripts.compileClasspath += configurations.compileClasspath
                     scripts.runtimeClasspath += configurations.compileClasspath
+                    test.compileClasspath += configurations.compileClasspath
+                    test.runtimeClasspath += configurations.compileClasspath
                 }
 
                 task ('prepareAddonSource', type: Sync) {


### PR DESCRIPTION
Source dir for scripts, 'src/scripts/groovy', was included in testImplementation. This is somewhat odd when you add specific dependencies for testing since they are not relevant to Freeplane groovy scripts. That is why this change request adds the configuration scriptsImplementation.

Changes to be committed:
	modified:   README.md -> v0.8
	modified:   build.gradle -> v0.8
	modified:   examples/greetings/build.gradle -> v0.8
	modified:   src/main/groovy/org/freeplane/gradleplugin/FreeplaneAddonPlugin.groovy
        line 32: added scriptsImplementation
        line 36: add main output as dependency
        line 54-58: sourceSet for scriptsImplementation
        line 78-79: apply to scripts (was test)